### PR TITLE
Use the vote times, rather than the current time on synchronisation.

### DIFF
--- a/src/AppBundle/CouchDocument/RequestForComment.php
+++ b/src/AppBundle/CouchDocument/RequestForComment.php
@@ -96,8 +96,8 @@ class RequestForComment
     public function setVotes(Votes $votes)
     {
         $this->currentVotes = array();
-        foreach ($votes as $username => $option) {
-            $this->currentVotes[$username] = $option;
+        foreach ($votes as $username => $vote) {
+            $this->currentVotes[$username] = $vote->getOption();
         }
     }
 

--- a/src/AppBundle/Model/Vote.php
+++ b/src/AppBundle/Model/Vote.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\Model;
+
+class Vote {
+    private $option;
+    private $time;
+
+    public function __construct($option, $time = null)
+    {
+        $this->option = $option;
+        $this->time = $time ?: new \DateTime;
+    }
+
+    public function __toString()
+    {
+        return $this->getOption();
+    }
+
+    public function getOption()
+    {
+        return $this->option;
+    }
+
+    public function getTime()
+    {
+        return $this->time;
+    }
+}

--- a/src/AppBundle/Model/Votes.php
+++ b/src/AppBundle/Model/Votes.php
@@ -58,17 +58,25 @@ class Votes implements IteratorAggregate, Countable
 
     public function diff(Votes $other)
     {
-        $added = array_diff_assoc($this->votes, $other->votes);
-        $removed = array_diff_assoc($other->votes, $this->votes);
+        if (is_string(current($this->votes))) {
+            $ourVotes = array_map(function ($vote) {
+                return new Vote($vote);
+            });
+        } else {
+            $ourVotes = $this->votes;
+        }
+
+        $added = array_diff_assoc($ourVotes, $other->votes);
+        $removed = array_diff_assoc($other->votes, $ourVotes);
 
         $newVotes = Votes::emptyVote();
-        foreach ($added as $username => $option) {
-            $newVotes = $newVotes->addVote($username, $option);
+        foreach ($added as $username => $vote) {
+            $newVotes = $newVotes->addVote($username, $vote);
         }
 
         $removedVotes = Votes::emptyVote();
-        foreach ($removed as $username => $option) {
-            $removedVotes = $removedVotes->addVote($username, $option);
+        foreach ($removed as $username => $vote) {
+            $removedVotes = $removedVotes->addVote($username, $vote);
         }
 
         return new VotesDiff($newVotes, $removedVotes);


### PR DESCRIPTION
This uses the times attached to the vote images, rather than the current time.

I would suggest deleting and recreating your CouchDB database before running the synchronisation command after applying this, although it's technically unnecessary, as it will apply the correct times to all votes in the database that way rather than only to those attached to new RFCs.