### PR TITLE
Feature - Client local time

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use DateTime;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -59,7 +60,7 @@ class DefaultController extends Controller
                 'option' => $event->getOption(),
                 'user' => $event->getUser(),
                 'vote' => ['id' => $event->getRfc()->getId(), 'title' => $event->getRfc()->getTitle(), 'url' => $event->getRfc()->getUrl()],
-                'date' => $event->getDate()->format('Y-m-d H:i:s'),
+                'date' => $event->getDate()->format(DateTime::ISO8601),
             ];
         }
 

--- a/src/js/components/Date.jsx
+++ b/src/js/components/Date.jsx
@@ -3,14 +3,19 @@ var React = require('react');
 var moment = require('./../vendor/moment.timezone');
 
 module.exports = React.createClass({
-    time: function() {
-        var time = moment(this.props.date).local().format('YY-MM-DD HH:mm');
+    timeDisplay: function() {
+        var time = moment(this.props.date).local().fromNow();
+        return time;
+    },
+    timeTitle: function() {
+        var time = moment(this.props.date).local().format('YYYY-MM-DD HH:mm:ss Z');
         return time;
     },
     render: function() {
         return (
             <span className="time">
-                <i className="fa fa-clock-o"></i> {this.time()}
+                <i className="fa fa-clock-o"></i>
+                <time dateTime={this.props.date} title={this.timeTitle()}>{this.timeDisplay()}</time>
             </span>
         );
     }

--- a/web/assets/rfcwatch.css
+++ b/web/assets/rfcwatch.css
@@ -22,3 +22,7 @@
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
 }
+
+.timeline-item .fa-clock-o {
+    margin-right: 4px;
+}


### PR DESCRIPTION
This small PR provides a nice little feature on top of a somewhat bug-fix.

Previously, the back-end was passing date values to the react front-end without a timezone. And while this project delivers on the best-practice of using UTC timezones for the back-end, that doesn't play so well once the data is passed to a front-end. See, browsers date handling (MomentJS's included) assumes that all time-zone-less date/time values are in the same time-zone as the client browser. Unfortunately that meant that the times in the timeline were always off by 5 hours for me (I'm in EST). This PR fixes that issue by always passing an ISO-8601 (includes timezone) date string to the front-end to handle.

While fixing that issue was ideal, this PR also aims to subtly improve the user experience of "PHP RFC Watch" by using the power of MomentJS's relative time handling. Now, when displaying times in the event timeline, we'll display a relative time in a more semantic HTML5 `time` tag (falls back to a span for older browsers). To give more clarity and to uphold an expected UI pattern, the `time` tag also uses the `title` attribute to provide a fully detailed time string when hovering over the element. Finally, we use the `time` tag's semantic data format to provide a client-parsable date format so that javascript extensions and added browser behaviors could be powered by the raw data. :)

Finally, I added a very small margin to the clock icon that prefixes the actual date string in the UI, just to relieve a minor cluttered appearance that I found when testing the date strings.

I'm really loving this project! Thanks for the awesome work. :smiley: 